### PR TITLE
Enable codeql workflow on push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,8 +12,8 @@
 name: "CodeQL"
 
 on:
-  # push:
-  #   branches: [ master ]
+  push:
+    branches: [ master, develop ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master, develop ]


### PR DESCRIPTION
Codeql needs to be able to compare to the base branch when checking a PR.