### PR TITLE
Remove selection after disabling input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,12 @@ const VerificationInput = forwardRef(
       }
     }, [autoFocus]);
 
+    useEffect(() => {
+      if(inputProps.disabled) {
+        setActive(false);
+      }
+    }, [inputProps.disabled])
+
     const handleClick = () => {
       inputRef.current.focus();
     };

--- a/src/verification-input.test.js
+++ b/src/verification-input.test.js
@@ -461,4 +461,18 @@ describe("VerificationInput", () => {
 
     expect(screen.getByRole("textbox")).toHaveAttribute("spellcheck", "false");
   });
+
+  it("should remove selection after disabling input", () => {
+    const { rerender } = render(<VerificationInput value={"1"} length={3} autoFocus={true} inputProps={{ disabled: false }} />);
+
+    expect(screen.getByTestId("character-0")).toHaveClass("vi__character", "vi__character--filled");
+    expect(screen.getByTestId("character-1")).toHaveClass("vi__character", "vi__character--selected");
+    expect(screen.getByTestId("character-2")).toHaveClass("vi__character", "vi__character--inactive");
+
+    rerender(<VerificationInput value={"1"} length={3} autoFocus={true} inputProps={{ disabled: true }} />)
+
+    expect(screen.getByTestId("character-0")).toHaveClass("vi__character", "vi__character--filled");
+    expect(screen.getByTestId("character-1")).toHaveClass("vi__character");
+    expect(screen.getByTestId("character-2")).toHaveClass("vi__character", "vi__character--inactive");
+  })
 });

--- a/src/verification-input.test.js
+++ b/src/verification-input.test.js
@@ -463,16 +463,45 @@ describe("VerificationInput", () => {
   });
 
   it("should remove selection after disabling input", () => {
-    const { rerender } = render(<VerificationInput value={"1"} length={3} autoFocus={true} inputProps={{ disabled: false }} />);
+    const { rerender } = render(
+      <VerificationInput
+        value={"1"}
+        length={3}
+        autoFocus={true}
+        inputProps={{ disabled: false }}
+      />
+    );
 
-    expect(screen.getByTestId("character-0")).toHaveClass("vi__character", "vi__character--filled");
-    expect(screen.getByTestId("character-1")).toHaveClass("vi__character", "vi__character--selected");
-    expect(screen.getByTestId("character-2")).toHaveClass("vi__character", "vi__character--inactive");
+    expect(screen.getByTestId("character-0")).toHaveClass(
+      "vi__character",
+      "vi__character--filled"
+    );
+    expect(screen.getByTestId("character-1")).toHaveClass(
+      "vi__character",
+      "vi__character--selected"
+    );
+    expect(screen.getByTestId("character-2")).toHaveClass(
+      "vi__character",
+      "vi__character--inactive"
+    );
 
-    rerender(<VerificationInput value={"1"} length={3} autoFocus={true} inputProps={{ disabled: true }} />)
+    rerender(
+      <VerificationInput
+        value={"1"}
+        length={3}
+        autoFocus={true}
+        inputProps={{ disabled: true }}
+      />
+    );
 
-    expect(screen.getByTestId("character-0")).toHaveClass("vi__character", "vi__character--filled");
+    expect(screen.getByTestId("character-0")).toHaveClass(
+      "vi__character",
+      "vi__character--filled"
+    );
     expect(screen.getByTestId("character-1")).toHaveClass("vi__character");
-    expect(screen.getByTestId("character-2")).toHaveClass("vi__character", "vi__character--inactive");
-  })
+    expect(screen.getByTestId("character-2")).toHaveClass(
+      "vi__character",
+      "vi__character--inactive"
+    );
+  });
 });


### PR DESCRIPTION
This PR fixes: https://github.com/andreaswilli/react-verification-input/issues/136

My initial idea was to support both below cases, however after some experimenting, I covered only 1st point:
1. when input becomes disabled -> change active to false
2. when input becomes enabled -> change active to true

Regarding 2nd point it may not be something that everyone expect. This point can be also easily handled anyway using `autoFocus` or `ref.current.focus()`. In my real case, I use autoFocus to select input again:
```  
<VerificationInput inputProps={{ disabled }} autoFocus={!disabled} />
```

Let me know if I should include some additional tests or changes?